### PR TITLE
Add groupEmit and userSockets Methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,6 @@ Streamy.emit('hello', { data: 'world!' }, s);
 
 Send a message with associated data to a socket. On the client, you do not need to provide the socket arg since it will use the client socket. On the server, **you must provide it**. If you want to send a message to all connected clients, you must use `Streamy.broadcast` (See Broadcasting).
 
-### Streamy.groupEmit(message_name, data_object, sockets) Server-only
-
-Send a message with associated data to a group of sockets. This differs from `Streamy.broadcast` in that you are choosing a specific group to send your message to.
-
 ### Streamy.on(message_name, callback)
 
 Register a callback for a specific message. The callback will be called when a message of this type has been received. Callback are of the form:
@@ -143,7 +139,7 @@ The server will add the property (client side) `data.__from` which contains the 
 
 ### Streamy.sockets([sid]) Server-only
 
-If no parameter is given, returns all connected socket objects. Else it will try to retrieve the socket associated with the given sid.
+If no parameter is given, returns all connected socket objects. If a string is provided it will try to retrieve the socket associated with the given sid. If an array is provided, it will try to retrieve the sockets for the given userIds.
 
 ### Streamy.id([socket])
 
@@ -166,7 +162,3 @@ Streamy.onConnect(function(socket) {
 ### Streamy.user([socket])
 
 Retrieve the meteor user. On the server, you should provide the socket object to retrieve the user associated.
-
-### Streamy.userSockets(user_ids) Server-only
-
-Retrieve sockets for a specific set of users. You should provide the desired users as an array of user ids.

--- a/README.md
+++ b/README.md
@@ -135,11 +135,15 @@ Streamy.sessions(other_guy_sid).emit('private', { body: 'This is a private messa
 
 The server will add the property (client side) `data.__from` which contains the sender session id.
 
+### Streamy.sessionsForUsers(uids) Server-only
+
+This method behaves similarly to `sessions`, however it looks up the sessions based on userIds. The special object it returns contains a single `emit` method that will send to every matched user.
+
 ## Utilities
 
 ### Streamy.sockets([sid]) Server-only
 
-If no parameter is given, returns all connected socket objects. If a string is provided it will try to retrieve the socket associated with the given sid. If an array is provided, it will try to retrieve the sockets for the given userIds.
+If no parameter is given, returns all connected socket objects. If a string is provided it will try to retrieve the socket associated with the given sid.
 
 ### Streamy.id([socket])
 

--- a/README.md
+++ b/README.md
@@ -162,3 +162,7 @@ Streamy.onConnect(function(socket) {
 ### Streamy.user([socket])
 
 Retrieve the meteor user. On the server, you should provide the socket object to retrieve the user associated.
+
+### Streamy.userSockets(user_ids) Server-only
+
+Retrieve sockets for a specific set of users. You should provide the desired users as an array of user ids.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Streamy.emit('hello', { data: 'world!' }, s);
 
 Send a message with associated data to a socket. On the client, you do not need to provide the socket arg since it will use the client socket. On the server, **you must provide it**. If you want to send a message to all connected clients, you must use `Streamy.broadcast` (See Broadcasting).
 
+### Streamy.groupEmit(message_name, data_object, sockets) Server-only
+
+Send a message with associated data to a group of sockets. This differs from `Streamy.broadcast` in that you are choosing a specific group to send your message to.
+
 ### Streamy.on(message_name, callback)
 
 Register a callback for a specific message. The callback will be called when a message of this type has been received. Callback are of the form:

--- a/lib/core/core_server.js
+++ b/lib/core/core_server.js
@@ -12,30 +12,45 @@ Streamy._usersId = {};
 
 /**
  * Retrieve server connected sockets or one in particular
- * @param {String|Array} sid Optional, String is socket id to retrieve, Array is list of userIds to retrieve sessions for
+ * @param {String} sid Optional, socket id to retrieve
  * @return  {Socket}  The socket object
  */
 Streamy.sockets = function(sid) {
   if(sid) {
-    if (typeof(sid) === 'string') {
-      var sock = sessions[sid];
-      if(!sock) // If not found creates a mock
-        sock = {
-          send: function() { }
-        };
-
-      return sock;
-    } else if (typeof(sid) === 'object') {
-      return _.chain(sessions).filter(function(socket) {
-        return sid.indexOf(socket._meteorSession.userId) != -1;
-      }).map(function(socket) {
-        return Streamy.sessions(socket);
-      }).value();
-    }
+    var sock = sessions[sid];
+    if(!sock) // If not found creates a mock
+      sock = {
+        send: function() { }
+      };
+      
+    return sock;
   }
-
+  
   return sessions;
 };
+
+/**
+ * Retrieve server connected sockets or one in particular by userId
+ * @param {String|Array} userIds, A single userId or an array of userIds to retrieve
+ * @return  {Object}  A special object with an emit method, that will send the passed in data to all matched sockets
+ */
+Streamy.sessionsForUsers = function(user_ids) {
+  if (typeof(user_ids) === 'string') user_ids = [user_ids];
+
+  var user_sessions = _.chain(Streamy.sockets()).filter(function(socket) {
+    return user_ids.indexOf(socket._meteorSession.userId) != -1;
+  }).map(function(socket) {
+    return Streamy.sessions(socket)
+  }).value();
+
+  return {
+    emit: function(msg, data) {
+      _.each(user_sessions, function(user_session) {
+        user_session.emit(msg, data);
+      });
+    }
+  };
+}
 
 // -------------------------------------------------------------------------- //
 // ------------------------------- Overrides -------------------------------- //

--- a/lib/core/core_server.js
+++ b/lib/core/core_server.js
@@ -12,20 +12,28 @@ Streamy._usersId = {};
 
 /**
  * Retrieve server connected sockets or one in particular
- * @param {String} sid Optional, socket id to retrieve
+ * @param {String|Array} sid Optional, String is socket id to retrieve, Array is list of userIds to retrieve sessions for
  * @return  {Socket}  The socket object
  */
 Streamy.sockets = function(sid) {
   if(sid) {
-    var sock = sessions[sid];
-    if(!sock) // If not found creates a mock
-      sock = {
-        send: function() { }
-      };
-      
-    return sock;
+    if (typeof(sid) === 'string') {
+      var sock = sessions[sid];
+      if(!sock) // If not found creates a mock
+        sock = {
+          send: function() { }
+        };
+
+      return sock;
+    } else if (typeof(sid) === 'object') {
+      return _.chain(sessions).filter(function(socket) {
+        return sid.indexOf(socket._meteorSession.userId) != -1;
+      }).map(function(socket) {
+        return Streamy.sessions(socket);
+      }).value();
+    }
   }
-  
+
   return sessions;
 };
 

--- a/lib/direct_messages/direct_messages_server.js
+++ b/lib/direct_messages/direct_messages_server.js
@@ -51,9 +51,3 @@ Streamy._sessionsEmit = function(sid) {
     Streamy.emit(msg, data, socket);
   };
 };
-
-Streamy.groupEmit = function(message, data, to) {
-  _.each(to, function(socket) {
-    Streamy.emit(message, data, socket);
-  });
-};

--- a/lib/direct_messages/direct_messages_server.js
+++ b/lib/direct_messages/direct_messages_server.js
@@ -51,3 +51,9 @@ Streamy._sessionsEmit = function(sid) {
     Streamy.emit(msg, data, socket);
   };
 };
+
+Streamy.groupEmit = function(message, data, to) {
+  _.each(to, function(socket) {
+    Streamy.emit(message, data, socket);
+  });
+};

--- a/lib/utils/utils_server.js
+++ b/lib/utils/utils_server.js
@@ -19,9 +19,3 @@ Streamy.user = function(socket) {
     
   return Meteor.users.findOne(Streamy.userId(socket));
 };
-
-Streamy.userSockets = function(user_ids) {
-  return _.filter(Streamy.sockets(), function(socket) {
-    return user_ids.indexOf(socket._meteorSession.userId) != -1;
-  });
-};

--- a/lib/utils/utils_server.js
+++ b/lib/utils/utils_server.js
@@ -19,3 +19,9 @@ Streamy.user = function(socket) {
     
   return Meteor.users.findOne(Streamy.userId(socket));
 };
+
+Streamy.userSockets = function(user_ids) {
+  return _.filter(Streamy.sockets(), function(socket) {
+    return user_ids.indexOf(socket._meteorSession.userId) != -1;
+  });
+};


### PR DESCRIPTION
Thank you for creating this package, it's been incredibly helpful for me!

When using it in my app, I ran into a couple of use cases that I thought might be helpful additions back to the package for others. This PR adds two new methods:

`userSockets` - Retrieve a list of sockets, looked up by passing in a list of userIds.

`groupEmit` - Send a message to a list of sockets. It's similar to `broadcast`, but instead of providing an exclusion blacklist, it takes an inclusion whitelist.

Please let me know what you think, and if there's any issues you'd like me to address.