### PR TITLE
Update sessionsForUsers to Only Accept UIDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The server will add the property (client side) `data.__from` which contains the 
 
 ### Streamy.sessionsForUsers(uid)
 
-This method behaves similarly to `sessions`, however it looks up the sessions based on user id(s). It returns a special object which contains one method: `emit` which works the same as the `core#emit` method. On the server, you can also send a socket in place of the uid parameter.
+This method behaves similarly to `sessions`, however it looks up the sessions based on user id(s). It returns a special object which contains one method: `emit` which works the same as the `core#emit` method.
 
 ## Utilities
 

--- a/lib/direct_messages/direct_messages_server.js
+++ b/lib/direct_messages/direct_messages_server.js
@@ -61,7 +61,8 @@ Streamy._sessionsEmit = function(sid) {
 };
 
 Streamy._sessionsForUsersEmit = function(uid) {
-  var sockets = _.isObject(uid) ? uid : Streamy.socketsForUsers(uid);
+  uid = _.isArray(uid) ? uid : [uid];
+  var sockets = Streamy.socketsForUsers(uid);
 
   return function(msg, data) {
     Streamy.emit(msg, data, sockets);


### PR DESCRIPTION
I noticed an issue due to allowing the `sessionsForUsers()` method to accept a socket. When passing in an array of user IDs, the check for `isObject` was getting a false positive and causing the method to fail. Reviewing further, I'm not sure there's a need for it to accept a socket, since the `sessions` method already serves that role and can be used if you want to pass in a socket. Please let me know if you see any issues with this reasoning.