### PR TITLE
Support methods to un-register messages' handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ Streamy.on('my_message', function(data, from) {
 });
 ```
 
+### Streamy.off(message_name)
+
+Un-register handler of a specific message.
+
+### Streamy.close() Client-only
+
+Un-register handlers of all messages on client.
+
 ### Streamy.onConnect(callback) / Streamy.onDisconnect(callback)
 
 Register callbacks to be called upon connection, disconnection. Please note that this is tied to the websockets only and has nothing to do with authentification.

--- a/lib/core/core.js
+++ b/lib/core/core.js
@@ -45,10 +45,10 @@ Streamy.handlers = function(message) {
     var handler = handlers[message];
     if(!handler)
       handler = function() {};
-      
+
     return handler;
   }
-  
+
   return handlers;
 };
 
@@ -76,6 +76,15 @@ Streamy.on = function(message, callback) {
 };
 
 /**
+ * Un-register an handler for the given message type
+ * @param {String} message Message name to handle
+ */
+Streamy.off = function(message) {
+  message = Streamy._applyPrefix(message);
+  delete handlers[message];
+};
+
+/**
  * Adds an handler for the connection success
  * @param {Function} callback Callback to call upon connection
  */
@@ -100,11 +109,11 @@ Streamy.onDisconnect = function(callback) {
 Streamy.emit = function(message, data, to) {
   data = data || {};
   message = Streamy._applyPrefix(message);
-  
+
   check(message, String);
   check(data, Object);
-  
+
   data.msg = message;
-  
+
   Streamy._write(JSON.stringify(data), to);
 };

--- a/lib/core/core_client.js
+++ b/lib/core/core_client.js
@@ -3,9 +3,9 @@
 // -------------------------------------------------------------------------- //
 
 Streamy.init = function() {
-  
+
   var self = this;
-  
+
   // Uppon close
   Meteor.default_connection._stream.on('disconnect', function onClose() {
     // If it was previously connected, call disconnect handlers
@@ -15,19 +15,19 @@ Streamy.init = function() {
       });
     }
   });
-  
+
   // Attach message handlers
   Meteor.default_connection._stream.on('message', function onMessage(data) {
 
     // Parse the message
     var parsed_data = JSON.parse(data);
-    
+
     // Retrieve the msg value
     var msg = parsed_data.msg;
-    
+
     // And dismiss it
     delete parsed_data.msg;
-    
+
     // If its the connected message
     if(msg === 'connected') {
       // Call each handlers
@@ -40,10 +40,22 @@ Streamy.init = function() {
       self.handlers(msg).call(self, parsed_data);
     }
   });
-  
-  
+
+
 };
 
 Streamy._write = function(data) {
   Meteor.default_connection._stream.send(data);
+};
+
+/**
+ * Un-register handlers of all messages on client
+ */
+Streamy.close = function() {
+  var handlers = Streamy.handlers();
+  for (var func in handlers) {
+    if (handlers.hasOwnProperty(func)) {
+      delete handlers[func];
+    }
+  }
 };


### PR DESCRIPTION
- `Streamy.off` method to un-register a certain message
- `Streamy.close` method to un-register all messages. This method is client-only.
- Update README to include two new methods

Related issue: #25 