### PR TITLE
Fix null session in filter

### DIFF
--- a/lib/core/core_server.js
+++ b/lib/core/core_server.js
@@ -52,7 +52,7 @@ Streamy.socketsForUsers = function(uid) {
     uid = _.isArray(uid) ? uid : [uid];
 
     var sockets = _.filter(Streamy.sockets(), function(socket) {
-      return uid.indexOf(socket._meteorSession.userId) !== -1;
+      return socket._meteorSession && uid.indexOf(socket._meteorSession.userId) !== -1;
     });
 
     return {

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'yuukan:streamy',
-  version: '1.4.0',
+  version: '1.4.1',
   // Brief, one-line summary of the package.
   summary: 'Simple interface to use the underlying sockjs in a meteor application',
   // URL to the Git repository containing the source code for this package.


### PR DESCRIPTION
### Scenario:

If a session is opened and the socket is active sending data, then the meteor session is off ( closing the window for example ) the session will not terminate, and `_meteorSession` will be nullified after a while, resulting in the filter call accessing a field on a null value.

This guard check is added to filter out any sockets with null `_meteorSession` fields