### PR TITLE
Renaming default_server to server and default_connection to connection

### DIFF
--- a/lib/core/core_client.js
+++ b/lib/core/core_client.js
@@ -7,9 +7,9 @@ Streamy.init = function() {
   var self = this;
 
   // Uppon close
-  Meteor.default_connection._stream.on('disconnect', function onClose() {
+  Meteor.connection._stream.on('disconnect', function onClose() {
     // If it was previously connected, call disconnect handlers
-    if(Meteor.default_connection._stream.status().connected) {
+    if(Meteor.connection._stream.status().connected) {
       _.each(self.disconnectHandlers(), function forEachDisconnectHandler(cb) {
         cb.call(self);
       });
@@ -17,7 +17,7 @@ Streamy.init = function() {
   });
 
   // Attach message handlers
-  Meteor.default_connection._stream.on('message', function onMessage(data) {
+  Meteor.connection._stream.on('message', function onMessage(data) {
 
     // Parse the message
     var parsed_data = JSON.parse(data);
@@ -45,7 +45,7 @@ Streamy.init = function() {
 };
 
 Streamy._write = function(data) {
-  Meteor.default_connection._stream.send(data);
+  Meteor.connection._stream.send(data);
 };
 
 /**

--- a/lib/core/core_server.js
+++ b/lib/core/core_server.js
@@ -84,7 +84,7 @@ Streamy.init = function() {
   }
 
   // When a new connection has been received
-  Meteor.default_server.stream_server.register(function onNewConnected(socket) {
+  Meteor.server.stream_server.register(function onNewConnected(socket) {
     var handlers_registered = false;
 
     // On closed, call disconnect handlers


### PR DESCRIPTION
This is for Meteor 2.3 compatibility (these were a legacy naming convention that was hanging around all the way from Meteor v0.6.5, 2013-08-14!)